### PR TITLE
feat(database): setup initial `vitess` configurations

### DIFF
--- a/vitess/README.md
+++ b/vitess/README.md
@@ -1,0 +1,7 @@
+### Vitess
+
+This is a quick local setup for using Vitess layer on top of MySQL, it essentially exposes just one mysql instance however the entire layer of database is managed by it.
+
+There are a few scripts that help you quickly spin up stuff that you need and the local directory contains the initial Vitess cluster configurations and most importantly the operator.
+
+We also have the portforwarding script that you will need in order to port forward the cluster endpoints to your local machine's endpoints.

--- a/vitess/local/01-initial-cluster.yaml
+++ b/vitess/local/01-initial-cluster.yaml
@@ -1,0 +1,233 @@
+apiVersion: planetscale.com/v2
+kind: VitessCluster
+metadata:
+  name: vitess-cluster
+spec:
+  images:
+    vtctld: vitess/lite:v16.0.0-mysql80
+    vtadmin: vitess/vtadmin:v16.0.0
+    vtgate: vitess/lite:v16.0.0-mysql80
+    vttablet: vitess/lite:v16.0.0-mysql80
+    vtbackup: vitess/lite:v16.0.0-mysql80
+    vtorc: vitess/lite:v16.0.0-mysql80
+    mysqld:
+      mysql56Compatible: vitess/lite:v16.0.0-mysql80
+    mysqldExporter: prom/mysqld-exporter:v0.11.0
+
+  cells:
+  - name: usEast1
+    gateway:
+      authentication:
+        static:
+          secret:
+            name: vitess-cluster-config
+            key: users.json
+      replicas: 1
+      extraFlags:
+        mysql_server_version: 8.0.30
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+
+  vitessDashboard:
+    cells:
+    - usEast1
+    extraFlags:
+      security_policy: read-only
+    replicas: 1
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+  
+  vtadmin:
+    rbac:
+      name: vitess-cluster-config
+      key: rbac.yaml
+    cells:
+      - usEast1
+    apiAddresses:
+      - http://localhost:14001
+    replicas: 1
+    readOnly: false
+    apiResources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    webResources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+  # These are essentially databases (more like logical databases)
+  keyspaces:
+  - name: alpha
+    turndownPolicy: Immediate
+    partitionings:
+    - equal:
+        parts: 1
+        shardTemplate:
+          databaseInitScriptSecret:
+            name: vitess-cluster-config
+            key: init_db.sql
+          tabletPools:
+          - cell: usEast1
+            type: replica
+            replicas: 2
+            vttablet:
+              extraFlags:
+                db_charset: utf8mb4
+              resources:
+                limits:
+                  memory: 1000Mi
+                requests:
+                  cpu: 256m
+                  memory: 1000Mi
+            mysqld:
+              resources:
+                limits:
+                  memory: 3000Mi
+                requests:
+                  cpu: 256m
+                  memory: 3000Mi
+            dataVolumeClaimTemplate:
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 10Gi
+
+  updateStrategy:
+    type: Immediate
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vitess-cluster-config
+type: Opaque
+stringData:
+  users.json: |
+    {
+      "user": [{
+        "UserData": "user",
+        "Password": ""
+      }]
+    }
+  init_db.sql: |
+    # This file is executed immediately after mysql_install_db,
+    # to initialize a fresh data directory.
+
+    ###############################################################################
+    # Equivalent of mysql_secure_installation
+    ###############################################################################
+
+    # Changes during the init db should not make it to the binlog.
+    # They could potentially create errant transactions on replicas.
+    SET sql_log_bin = 0;
+    # Remove anonymous users.
+    DELETE FROM mysql.user WHERE User = '';
+
+    # Disable remote root access (only allow UNIX socket).
+    DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
+
+    # Remove test database.
+    DROP DATABASE IF EXISTS test;
+
+    ###############################################################################
+    # Vitess defaults
+    ###############################################################################
+
+    # Vitess-internal database.
+    CREATE DATABASE IF NOT EXISTS _vt;
+    # Note that definitions of local_metadata and shard_metadata should be the same
+    # as in production which is defined in go/vt/mysqlctl/metadata_tables.go.
+    CREATE TABLE IF NOT EXISTS _vt.local_metadata (
+      name VARCHAR(255) NOT NULL,
+      value VARCHAR(255) NOT NULL,
+      db_name VARBINARY(255) NOT NULL,
+      PRIMARY KEY (db_name, name)
+      ) ENGINE=InnoDB;
+    CREATE TABLE IF NOT EXISTS _vt.shard_metadata (
+      name VARCHAR(255) NOT NULL,
+      value MEDIUMBLOB NOT NULL,
+      db_name VARBINARY(255) NOT NULL,
+      PRIMARY KEY (db_name, name)
+      ) ENGINE=InnoDB;
+
+    # Admin user with all privileges.
+    CREATE USER 'vt_dba'@'localhost';
+    GRANT ALL ON *.* TO 'vt_dba'@'localhost';
+    GRANT GRANT OPTION ON *.* TO 'vt_dba'@'localhost';
+
+    # User for app traffic, with global read-write access.
+    CREATE USER 'vt_app'@'localhost';
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+      REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+      LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
+      SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+      ON *.* TO 'vt_app'@'localhost';
+
+    # User for app debug traffic, with global read access.
+    CREATE USER 'vt_appdebug'@'localhost';
+    GRANT SELECT, SHOW DATABASES, PROCESS ON *.* TO 'vt_appdebug'@'localhost';
+
+    # User for administrative operations that need to be executed as non-SUPER.
+    # Same permissions as vt_app here.
+    CREATE USER 'vt_allprivs'@'localhost';
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+      REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+      LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
+      SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+      ON *.* TO 'vt_allprivs'@'localhost';
+
+    # User for slave replication connections.
+    # TODO: Should we set a password on this since it allows remote connections?
+    CREATE USER 'vt_repl'@'%';
+    GRANT REPLICATION SLAVE ON *.* TO 'vt_repl'@'%';
+
+    # User for Vitess filtered replication (binlog player).
+    # Same permissions as vt_app.
+    CREATE USER 'vt_filtered'@'localhost';
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
+      REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
+      LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW,
+      SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+      ON *.* TO 'vt_filtered'@'localhost';
+
+    # User for Orchestrator (https://github.com/openark/orchestrator).
+    # TODO: Reenable when the password is randomly generated.
+    # CREATE USER 'orc_client_user'@'%' IDENTIFIED BY 'orc_client_user_password';
+    # GRANT SUPER, PROCESS, REPLICATION SLAVE, RELOAD
+    #  ON *.* TO 'orc_client_user'@'%';
+    # GRANT SELECT
+    #  ON _vt.* TO 'orc_client_user'@'%';
+
+    FLUSH PRIVILEGES;
+
+    RESET SLAVE ALL;
+    RESET MASTER;
+  rbac.yaml: |
+    rules:
+    - resource: "*"
+      actions:
+        - "get"
+        - "create"
+        - "put"
+        - "ping"
+      subjects: ["*"]
+      clusters: ["*"]
+    - resource: "Shard"
+      actions:
+        - "emergency_failover_shard"
+        - "planned_failover_shard"
+      subjects: ["*"]
+      clusters: ["*"]

--- a/vitess/local/operator.yaml
+++ b/vitess/local/operator.yaml
@@ -1,0 +1,6173 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: etcdlockservers.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: EtcdLockserver
+    listKind: EtcdLockserverList
+    plural: etcdlockservers
+    shortNames:
+      - etcdls
+    singular: etcdlockserver
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                advertisePeerURLs:
+                  items:
+                    type: string
+                  maxItems: 3
+                  minItems: 3
+                  type: array
+                affinity:
+                  x-kubernetes-preserve-unknown-fields: true
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                clientService:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    clusterIP:
+                      type: string
+                  type: object
+                createClientService:
+                  type: boolean
+                createPDB:
+                  type: boolean
+                createPeerService:
+                  type: boolean
+                dataVolumeClaimTemplate:
+                  properties:
+                    accessModes:
+                      items:
+                        type: string
+                      type: array
+                    dataSource:
+                      properties:
+                        apiGroup:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                        - kind
+                        - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    dataSourceRef:
+                      properties:
+                        apiGroup:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - kind
+                        - name
+                      type: object
+                    resources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    selector:
+                      properties:
+                        matchExpressions:
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    storageClassName:
+                      type: string
+                    volumeMode:
+                      type: string
+                    volumeName:
+                      type: string
+                  type: object
+                extraEnv:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          configMapKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            properties:
+                              apiVersion:
+                                type: string
+                              fieldPath:
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            properties:
+                              containerName:
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                extraFlags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                extraLabels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                extraVolumeMounts:
+                  items:
+                    properties:
+                      mountPath:
+                        type: string
+                      mountPropagation:
+                        type: string
+                      name:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                      - mountPath
+                      - name
+                    type: object
+                  type: array
+                extraVolumes:
+                  x-kubernetes-preserve-unknown-fields: true
+                image:
+                  type: string
+                imagePullPolicy:
+                  type: string
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                initContainers:
+                  x-kubernetes-preserve-unknown-fields: true
+                localMemberIndex:
+                  format: int32
+                  maximum: 3
+                  minimum: 1
+                  type: integer
+                peerService:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    clusterIP:
+                      type: string
+                  type: object
+                resources:
+                  properties:
+                    claims:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                sidecarContainers:
+                  x-kubernetes-preserve-unknown-fields: true
+                tolerations:
+                  x-kubernetes-preserve-unknown-fields: true
+                zone:
+                  type: string
+              type: object
+            status:
+              properties:
+                available:
+                  type: string
+                clientServiceName:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: vitessbackups.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessBackup
+    listKind: VitessBackupList
+    plural: vitessbackups
+    shortNames:
+      - vtb
+    singular: vitessbackup
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+            status:
+              properties:
+                complete:
+                  type: boolean
+                engine:
+                  type: string
+                finishedTime:
+                  format: date-time
+                  type: string
+                position:
+                  type: string
+                startTime:
+                  format: date-time
+                  type: string
+                storageDirectory:
+                  type: string
+                storageName:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: vitessbackupstorages.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessBackupStorage
+    listKind: VitessBackupStorageList
+    plural: vitessbackupstorages
+    shortNames:
+      - vtbs
+    singular: vitessbackupstorage
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                location:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    azblob:
+                      properties:
+                        account:
+                          minLength: 1
+                          type: string
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        container:
+                          minLength: 1
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                      required:
+                        - account
+                        - authSecret
+                        - container
+                      type: object
+                    ceph:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                      required:
+                        - authSecret
+                      type: object
+                    gcs:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        bucket:
+                          minLength: 1
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                      required:
+                        - bucket
+                      type: object
+                    name:
+                      maxLength: 63
+                      pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                      type: string
+                    s3:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        bucket:
+                          minLength: 1
+                          type: string
+                        endpoint:
+                          type: string
+                        forcePathStyle:
+                          type: boolean
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                        region:
+                          minLength: 1
+                          type: string
+                      required:
+                        - bucket
+                        - region
+                      type: object
+                    volume:
+                      x-kubernetes-preserve-unknown-fields: true
+                    volumeSubPath:
+                      type: string
+                  type: object
+                subcontroller:
+                  properties:
+                    serviceAccountName:
+                      type: string
+                  type: object
+              required:
+                - location
+              type: object
+            status:
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+                totalBackupCount:
+                  format: int32
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: vitesscells.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessCell
+    listKind: VitessCellList
+    plural: vitesscells
+    shortNames:
+      - vtc
+    singular: vitesscell
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                allCells:
+                  items:
+                    type: string
+                  type: array
+                extraVitessFlags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                gateway:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    authentication:
+                      properties:
+                        static:
+                          properties:
+                            secret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                          type: object
+                      type: object
+                    extraEnv:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    extraFlags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraVolumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      x-kubernetes-preserve-unknown-fields: true
+                    initContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    replicas:
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    secureTransport:
+                      properties:
+                        required:
+                          type: boolean
+                        tls:
+                          properties:
+                            certSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                            clientCACertSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                            keySecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                          type: object
+                      type: object
+                    service:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clusterIP:
+                          type: string
+                      type: object
+                    sidecarContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    tolerations:
+                      x-kubernetes-preserve-unknown-fields: true
+                    topologySpreadConstraints:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                globalLockserver:
+                  properties:
+                    address:
+                      type: string
+                    implementation:
+                      type: string
+                    rootPath:
+                      type: string
+                  required:
+                    - address
+                    - implementation
+                    - rootPath
+                  type: object
+                imagePullPolicies:
+                  properties:
+                    mysqld:
+                      type: string
+                    mysqldExporter:
+                      type: string
+                    vtadmin:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                images:
+                  properties:
+                    vtgate:
+                      type: string
+                  type: object
+                lockserver:
+                  properties:
+                    cellInfoAddress:
+                      type: string
+                    etcd:
+                      properties:
+                        advertisePeerURLs:
+                          items:
+                            type: string
+                          maxItems: 3
+                          minItems: 3
+                          type: array
+                        affinity:
+                          x-kubernetes-preserve-unknown-fields: true
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clientService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterIP:
+                              type: string
+                          type: object
+                        createClientService:
+                          type: boolean
+                        createPDB:
+                          type: boolean
+                        createPeerService:
+                          type: boolean
+                        dataVolumeClaimTemplate:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                        extraEnv:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        extraFlags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        extraLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        extraVolumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        extraVolumes:
+                          x-kubernetes-preserve-unknown-fields: true
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        initContainers:
+                          x-kubernetes-preserve-unknown-fields: true
+                        localMemberIndex:
+                          format: int32
+                          maximum: 3
+                          minimum: 1
+                          type: integer
+                        peerService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterIP:
+                              type: string
+                          type: object
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        sidecarContainers:
+                          x-kubernetes-preserve-unknown-fields: true
+                        tolerations:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    external:
+                      properties:
+                        address:
+                          type: string
+                        implementation:
+                          type: string
+                        rootPath:
+                          type: string
+                      required:
+                        - address
+                        - implementation
+                        - rootPath
+                      type: object
+                  type: object
+                name:
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                  type: string
+                topologyReconciliation:
+                  properties:
+                    pruneCells:
+                      type: boolean
+                    pruneKeyspaces:
+                      type: boolean
+                    pruneShardCells:
+                      type: boolean
+                    pruneShards:
+                      type: boolean
+                    pruneSrvKeyspaces:
+                      type: boolean
+                    pruneTablets:
+                      type: boolean
+                    registerCells:
+                      type: boolean
+                    registerCellsAliases:
+                      type: boolean
+                  type: object
+                zone:
+                  type: string
+              required:
+                - allCells
+                - globalLockserver
+                - name
+              type: object
+            status:
+              properties:
+                gateway:
+                  properties:
+                    available:
+                      type: string
+                    serviceName:
+                      type: string
+                  type: object
+                idle:
+                  type: string
+                keyspaces:
+                  additionalProperties:
+                    type: object
+                  type: object
+                lockserver:
+                  properties:
+                    etcd:
+                      properties:
+                        available:
+                          type: string
+                        clientServiceName:
+                          type: string
+                        observedGeneration:
+                          format: int64
+                          type: integer
+                      type: object
+                  type: object
+                observedGeneration:
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: vitessclusters.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessCluster
+    listKind: VitessClusterList
+    plural: vitessclusters
+    shortNames:
+      - vt
+    singular: vitesscluster
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                backup:
+                  properties:
+                    engine:
+                      enum:
+                        - builtin
+                        - xtrabackup
+                      type: string
+                    locations:
+                      items:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          azblob:
+                            properties:
+                              account:
+                                minLength: 1
+                                type: string
+                              authSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              container:
+                                minLength: 1
+                                type: string
+                              keyPrefix:
+                                maxLength: 256
+                                pattern: ^[^\r\n]*$
+                                type: string
+                            required:
+                              - account
+                              - authSecret
+                              - container
+                            type: object
+                          ceph:
+                            properties:
+                              authSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                            required:
+                              - authSecret
+                            type: object
+                          gcs:
+                            properties:
+                              authSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              bucket:
+                                minLength: 1
+                                type: string
+                              keyPrefix:
+                                maxLength: 256
+                                pattern: ^[^\r\n]*$
+                                type: string
+                            required:
+                              - bucket
+                            type: object
+                          name:
+                            maxLength: 63
+                            pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                            type: string
+                          s3:
+                            properties:
+                              authSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              bucket:
+                                minLength: 1
+                                type: string
+                              endpoint:
+                                type: string
+                              forcePathStyle:
+                                type: boolean
+                              keyPrefix:
+                                maxLength: 256
+                                pattern: ^[^\r\n]*$
+                                type: string
+                              region:
+                                minLength: 1
+                                type: string
+                            required:
+                              - bucket
+                              - region
+                            type: object
+                          volume:
+                            x-kubernetes-preserve-unknown-fields: true
+                          volumeSubPath:
+                            type: string
+                        type: object
+                      minItems: 1
+                      type: array
+                    subcontroller:
+                      properties:
+                        serviceAccountName:
+                          type: string
+                      type: object
+                  required:
+                    - locations
+                  type: object
+                cells:
+                  items:
+                    properties:
+                      gateway:
+                        properties:
+                          affinity:
+                            x-kubernetes-preserve-unknown-fields: true
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          authentication:
+                            properties:
+                              static:
+                                properties:
+                                  secret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            type: object
+                          extraEnv:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          extraFlags:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          extraLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          extraVolumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            x-kubernetes-preserve-unknown-fields: true
+                          initContainers:
+                            x-kubernetes-preserve-unknown-fields: true
+                          replicas:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          secureTransport:
+                            properties:
+                              required:
+                                type: boolean
+                              tls:
+                                properties:
+                                  certSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                      - key
+                                    type: object
+                                  clientCACertSecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                      - key
+                                    type: object
+                                  keySecret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            type: object
+                          service:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              clusterIP:
+                                type: string
+                            type: object
+                          sidecarContainers:
+                            x-kubernetes-preserve-unknown-fields: true
+                          tolerations:
+                            x-kubernetes-preserve-unknown-fields: true
+                          topologySpreadConstraints:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      lockserver:
+                        properties:
+                          cellInfoAddress:
+                            type: string
+                          etcd:
+                            properties:
+                              advertisePeerURLs:
+                                items:
+                                  type: string
+                                maxItems: 3
+                                minItems: 3
+                                type: array
+                              affinity:
+                                x-kubernetes-preserve-unknown-fields: true
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              clientService:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  clusterIP:
+                                    type: string
+                                type: object
+                              createClientService:
+                                type: boolean
+                              createPDB:
+                                type: boolean
+                              createPeerService:
+                                type: boolean
+                              dataVolumeClaimTemplate:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  dataSourceRef:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                              extraEnv:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                              extraFlags:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              extraLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              extraVolumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                    - mountPath
+                                    - name
+                                  type: object
+                                type: array
+                              extraVolumes:
+                                x-kubernetes-preserve-unknown-fields: true
+                              image:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                              initContainers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              localMemberIndex:
+                                format: int32
+                                maximum: 3
+                                minimum: 1
+                                type: integer
+                              peerService:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  clusterIP:
+                                    type: string
+                                type: object
+                              resources:
+                                properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              sidecarContainers:
+                                x-kubernetes-preserve-unknown-fields: true
+                              tolerations:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          external:
+                            properties:
+                              address:
+                                type: string
+                              implementation:
+                                type: string
+                              rootPath:
+                                type: string
+                            required:
+                              - address
+                              - implementation
+                              - rootPath
+                            type: object
+                        type: object
+                      name:
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                        type: string
+                      zone:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                extraVitessFlags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                gatewayService:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    clusterIP:
+                      type: string
+                  type: object
+                globalLockserver:
+                  properties:
+                    cellInfoAddress:
+                      type: string
+                    etcd:
+                      properties:
+                        advertisePeerURLs:
+                          items:
+                            type: string
+                          maxItems: 3
+                          minItems: 3
+                          type: array
+                        affinity:
+                          x-kubernetes-preserve-unknown-fields: true
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clientService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterIP:
+                              type: string
+                          type: object
+                        createClientService:
+                          type: boolean
+                        createPDB:
+                          type: boolean
+                        createPeerService:
+                          type: boolean
+                        dataVolumeClaimTemplate:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                        extraEnv:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        extraFlags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        extraLabels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        extraVolumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        extraVolumes:
+                          x-kubernetes-preserve-unknown-fields: true
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        initContainers:
+                          x-kubernetes-preserve-unknown-fields: true
+                        localMemberIndex:
+                          format: int32
+                          maximum: 3
+                          minimum: 1
+                          type: integer
+                        peerService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterIP:
+                              type: string
+                          type: object
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        sidecarContainers:
+                          x-kubernetes-preserve-unknown-fields: true
+                        tolerations:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    external:
+                      properties:
+                        address:
+                          type: string
+                        implementation:
+                          type: string
+                        rootPath:
+                          type: string
+                      required:
+                        - address
+                        - implementation
+                        - rootPath
+                      type: object
+                  type: object
+                imagePullPolicies:
+                  properties:
+                    mysqld:
+                      type: string
+                    mysqldExporter:
+                      type: string
+                    vtadmin:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                images:
+                  properties:
+                    mysqld:
+                      properties:
+                        mariadb103Compatible:
+                          type: string
+                        mariadbCompatible:
+                          type: string
+                        mysql56Compatible:
+                          type: string
+                        mysql80Compatible:
+                          type: string
+                      type: object
+                    mysqldExporter:
+                      type: string
+                    vtadmin:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                keyspaces:
+                  items:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      databaseName:
+                        type: string
+                      durabilityPolicy:
+                        type: string
+                      name:
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                        type: string
+                      partitionings:
+                        items:
+                          properties:
+                            custom:
+                              properties:
+                                shards:
+                                  items:
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      databaseInitScriptSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                          - key
+                                        type: object
+                                      keyRange:
+                                        properties:
+                                          end:
+                                            pattern: ^([0-9a-f][0-9a-f])*$
+                                            type: string
+                                          start:
+                                            pattern: ^([0-9a-f][0-9a-f])*$
+                                            type: string
+                                        type: object
+                                      replication:
+                                        properties:
+                                          initializeBackup:
+                                            type: boolean
+                                          initializeMaster:
+                                            type: boolean
+                                          recoverRestartedMaster:
+                                            type: boolean
+                                        type: object
+                                      tabletPools:
+                                        items:
+                                          properties:
+                                            affinity:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            backupLocationName:
+                                              type: string
+                                            cell:
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                                              type: string
+                                            dataVolumeClaimTemplate:
+                                              properties:
+                                                accessModes:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - kind
+                                                    - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                  required:
+                                                    - kind
+                                                    - name
+                                                  type: object
+                                                resources:
+                                                  properties:
+                                                    claims:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                        required:
+                                                          - name
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                        - name
+                                                      x-kubernetes-list-type: map
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                          - key
+                                                          - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  type: string
+                                                volumeMode:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              type: object
+                                            externalDatastore:
+                                              properties:
+                                                credentialsSecret:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                database:
+                                                  type: string
+                                                host:
+                                                  type: string
+                                                port:
+                                                  format: int32
+                                                  maximum: 65535
+                                                  minimum: 1
+                                                  type: integer
+                                                serverCACertSecret:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                user:
+                                                  type: string
+                                              required:
+                                                - credentialsSecret
+                                                - database
+                                                - host
+                                                - port
+                                                - user
+                                              type: object
+                                            extraEnv:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                          - key
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        required:
+                                                          - fieldPath
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            type: string
+                                                        required:
+                                                          - resource
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      secretKeyRef:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                        required:
+                                                          - key
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                    type: object
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
+                                            extraLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            extraVolumeMounts:
+                                              items:
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                                required:
+                                                  - mountPath
+                                                  - name
+                                                type: object
+                                              type: array
+                                            extraVolumes:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            initContainers:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            mysqld:
+                                              properties:
+                                                configOverrides:
+                                                  type: string
+                                                resources:
+                                                  properties:
+                                                    claims:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                        required:
+                                                          - name
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                        - name
+                                                      x-kubernetes-list-type: map
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - resources
+                                              type: object
+                                            replicas:
+                                              format: int32
+                                              minimum: 0
+                                              type: integer
+                                            sidecarContainers:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            tolerations:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            topologySpreadConstraints:
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type:
+                                              enum:
+                                                - replica
+                                                - rdonly
+                                                - externalmaster
+                                                - externalreplica
+                                                - externalrdonly
+                                              type: string
+                                            vttablet:
+                                              properties:
+                                                extraFlags:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                lifecycle:
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                resources:
+                                                  properties:
+                                                    claims:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                        required:
+                                                          - name
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                        - name
+                                                      x-kubernetes-list-type: map
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                              required:
+                                                - resources
+                                              type: object
+                                          required:
+                                            - cell
+                                            - replicas
+                                            - type
+                                            - vttablet
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - type
+                                          - cell
+                                        x-kubernetes-list-type: map
+                                    required:
+                                      - databaseInitScriptSecret
+                                      - keyRange
+                                    type: object
+                                  type: array
+                              required:
+                                - shards
+                              type: object
+                            equal:
+                              properties:
+                                parts:
+                                  format: int32
+                                  maximum: 65536
+                                  minimum: 1
+                                  type: integer
+                                shardTemplate:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    databaseInitScriptSecret:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    replication:
+                                      properties:
+                                        initializeBackup:
+                                          type: boolean
+                                        initializeMaster:
+                                          type: boolean
+                                        recoverRestartedMaster:
+                                          type: boolean
+                                      type: object
+                                    tabletPools:
+                                      items:
+                                        properties:
+                                          affinity:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          backupLocationName:
+                                            type: string
+                                          cell:
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                                            type: string
+                                          dataVolumeClaimTemplate:
+                                            properties:
+                                              accessModes:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              dataSource:
+                                                properties:
+                                                  apiGroup:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                required:
+                                                  - kind
+                                                  - name
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              dataSourceRef:
+                                                properties:
+                                                  apiGroup:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
+                                                required:
+                                                  - kind
+                                                  - name
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                      - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              storageClassName:
+                                                type: string
+                                              volumeMode:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            type: object
+                                          externalDatastore:
+                                            properties:
+                                              credentialsSecret:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                type: object
+                                              database:
+                                                type: string
+                                              host:
+                                                type: string
+                                              port:
+                                                format: int32
+                                                maximum: 65535
+                                                minimum: 1
+                                                type: integer
+                                              serverCACertSecret:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                  - key
+                                                type: object
+                                              user:
+                                                type: string
+                                            required:
+                                              - credentialsSecret
+                                              - database
+                                              - host
+                                              - port
+                                              - user
+                                            type: object
+                                          extraEnv:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                                valueFrom:
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                        - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                        - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secretKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                        - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                          extraLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          extraVolumeMounts:
+                                            items:
+                                              properties:
+                                                mountPath:
+                                                  type: string
+                                                mountPropagation:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                subPath:
+                                                  type: string
+                                                subPathExpr:
+                                                  type: string
+                                              required:
+                                                - mountPath
+                                                - name
+                                              type: object
+                                            type: array
+                                          extraVolumes:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          initContainers:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          mysqld:
+                                            properties:
+                                              configOverrides:
+                                                type: string
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                      - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                            required:
+                                              - resources
+                                            type: object
+                                          replicas:
+                                            format: int32
+                                            minimum: 0
+                                            type: integer
+                                          sidecarContainers:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          tolerations:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          topologySpreadConstraints:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type:
+                                            enum:
+                                              - replica
+                                              - rdonly
+                                              - externalmaster
+                                              - externalreplica
+                                              - externalrdonly
+                                            type: string
+                                          vttablet:
+                                            properties:
+                                              extraFlags:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              lifecycle:
+                                                x-kubernetes-preserve-unknown-fields: true
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                      - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                            required:
+                                              - resources
+                                            type: object
+                                        required:
+                                          - cell
+                                          - replicas
+                                          - type
+                                          - vttablet
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - type
+                                        - cell
+                                      x-kubernetes-list-type: map
+                                  required:
+                                    - databaseInitScriptSecret
+                                  type: object
+                              required:
+                                - parts
+                              type: object
+                          type: object
+                        maxItems: 2
+                        minItems: 1
+                        type: array
+                      turndownPolicy:
+                        enum:
+                          - RequireIdle
+                          - Immediate
+                        type: string
+                      vitessOrchestrator:
+                        properties:
+                          affinity:
+                            x-kubernetes-preserve-unknown-fields: true
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          extraEnv:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          extraFlags:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          extraLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          extraVolumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            x-kubernetes-preserve-unknown-fields: true
+                          initContainers:
+                            x-kubernetes-preserve-unknown-fields: true
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          service:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              clusterIP:
+                                type: string
+                            type: object
+                          sidecarContainers:
+                            x-kubernetes-preserve-unknown-fields: true
+                          tolerations:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    required:
+                      - name
+                      - partitionings
+                    type: object
+                  type: array
+                tabletService:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    clusterIP:
+                      type: string
+                  type: object
+                topologyReconciliation:
+                  properties:
+                    pruneCells:
+                      type: boolean
+                    pruneKeyspaces:
+                      type: boolean
+                    pruneShardCells:
+                      type: boolean
+                    pruneShards:
+                      type: boolean
+                    pruneSrvKeyspaces:
+                      type: boolean
+                    pruneTablets:
+                      type: boolean
+                    registerCells:
+                      type: boolean
+                    registerCellsAliases:
+                      type: boolean
+                  type: object
+                updateStrategy:
+                  properties:
+                    external:
+                      properties:
+                        allowResourceChanges:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type:
+                      enum:
+                        - External
+                        - Immediate
+                      type: string
+                  type: object
+                vitessDashboard:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    cells:
+                      items:
+                        type: string
+                      type: array
+                    extraEnv:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    extraFlags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraVolumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      x-kubernetes-preserve-unknown-fields: true
+                    initContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    replicas:
+                      format: int32
+                      type: integer
+                    resources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    service:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clusterIP:
+                          type: string
+                      type: object
+                    sidecarContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    tolerations:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                vtadmin:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    apiAddresses:
+                      items:
+                        type: string
+                      type: array
+                    apiResources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    cells:
+                      items:
+                        type: string
+                      type: array
+                    extraEnv:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    extraFlags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraVolumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      x-kubernetes-preserve-unknown-fields: true
+                    initContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    rbac:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                        volumeName:
+                          type: string
+                      required:
+                        - key
+                      type: object
+                    readOnly:
+                      type: boolean
+                    replicas:
+                      format: int32
+                      type: integer
+                    service:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clusterIP:
+                          type: string
+                      type: object
+                    sidecarContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    tolerations:
+                      x-kubernetes-preserve-unknown-fields: true
+                    webResources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                  required:
+                    - apiAddresses
+                  type: object
+              required:
+                - cells
+              type: object
+            status:
+              properties:
+                cells:
+                  additionalProperties:
+                    properties:
+                      gatewayAvailable:
+                        type: string
+                      pendingChanges:
+                        type: string
+                    type: object
+                  type: object
+                gatewayServiceName:
+                  type: string
+                globalLockserver:
+                  properties:
+                    etcd:
+                      properties:
+                        available:
+                          type: string
+                        clientServiceName:
+                          type: string
+                        observedGeneration:
+                          format: int64
+                          type: integer
+                      type: object
+                  type: object
+                keyspaces:
+                  additionalProperties:
+                    properties:
+                      cells:
+                        items:
+                          type: string
+                        type: array
+                      desiredShards:
+                        format: int32
+                        type: integer
+                      desiredTablets:
+                        format: int32
+                        type: integer
+                      pendingChanges:
+                        type: string
+                      readyShards:
+                        format: int32
+                        type: integer
+                      readyTablets:
+                        format: int32
+                        type: integer
+                      shards:
+                        format: int32
+                        type: integer
+                      tablets:
+                        format: int32
+                        type: integer
+                      updatedShards:
+                        format: int32
+                        type: integer
+                      updatedTablets:
+                        format: int32
+                        type: integer
+                    type: object
+                  type: object
+                observedGeneration:
+                  format: int64
+                  type: integer
+                orphanedCells:
+                  additionalProperties:
+                    properties:
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                    required:
+                      - message
+                      - reason
+                    type: object
+                  type: object
+                orphanedKeyspaces:
+                  additionalProperties:
+                    properties:
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                    required:
+                      - message
+                      - reason
+                    type: object
+                  type: object
+                vitessDashboard:
+                  properties:
+                    available:
+                      type: string
+                    serviceName:
+                      type: string
+                  type: object
+                vtadmin:
+                  properties:
+                    available:
+                      type: string
+                    serviceName:
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: vitesskeyspaces.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessKeyspace
+    listKind: VitessKeyspaceList
+    plural: vitesskeyspaces
+    shortNames:
+      - vtk
+    singular: vitesskeyspace
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                backupEngine:
+                  type: string
+                backupLocations:
+                  items:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      azblob:
+                        properties:
+                          account:
+                            minLength: 1
+                            type: string
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          container:
+                            minLength: 1
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                        required:
+                          - account
+                          - authSecret
+                          - container
+                        type: object
+                      ceph:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                        required:
+                          - authSecret
+                        type: object
+                      gcs:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            minLength: 1
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                        required:
+                          - bucket
+                        type: object
+                      name:
+                        maxLength: 63
+                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                        type: string
+                      s3:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            minLength: 1
+                            type: string
+                          endpoint:
+                            type: string
+                          forcePathStyle:
+                            type: boolean
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                          region:
+                            minLength: 1
+                            type: string
+                        required:
+                          - bucket
+                          - region
+                        type: object
+                      volume:
+                        x-kubernetes-preserve-unknown-fields: true
+                      volumeSubPath:
+                        type: string
+                    type: object
+                  type: array
+                databaseName:
+                  type: string
+                durabilityPolicy:
+                  type: string
+                extraVitessFlags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                globalLockserver:
+                  properties:
+                    address:
+                      type: string
+                    implementation:
+                      type: string
+                    rootPath:
+                      type: string
+                  required:
+                    - address
+                    - implementation
+                    - rootPath
+                  type: object
+                imagePullPolicies:
+                  properties:
+                    mysqld:
+                      type: string
+                    mysqldExporter:
+                      type: string
+                    vtadmin:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                images:
+                  properties:
+                    mysqld:
+                      properties:
+                        mariadb103Compatible:
+                          type: string
+                        mariadbCompatible:
+                          type: string
+                        mysql56Compatible:
+                          type: string
+                        mysql80Compatible:
+                          type: string
+                      type: object
+                    mysqldExporter:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                name:
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                  type: string
+                partitionings:
+                  items:
+                    properties:
+                      custom:
+                        properties:
+                          shards:
+                            items:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                databaseInitScriptSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                    - key
+                                  type: object
+                                keyRange:
+                                  properties:
+                                    end:
+                                      pattern: ^([0-9a-f][0-9a-f])*$
+                                      type: string
+                                    start:
+                                      pattern: ^([0-9a-f][0-9a-f])*$
+                                      type: string
+                                  type: object
+                                replication:
+                                  properties:
+                                    initializeBackup:
+                                      type: boolean
+                                    initializeMaster:
+                                      type: boolean
+                                    recoverRestartedMaster:
+                                      type: boolean
+                                  type: object
+                                tabletPools:
+                                  items:
+                                    properties:
+                                      affinity:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      backupLocationName:
+                                        type: string
+                                      cell:
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                                        type: string
+                                      dataVolumeClaimTemplate:
+                                        properties:
+                                          accessModes:
+                                            items:
+                                              type: string
+                                            type: array
+                                          dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          resources:
+                                            properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          selector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            type: string
+                                          volumeMode:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                      externalDatastore:
+                                        properties:
+                                          credentialsSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                              - key
+                                            type: object
+                                          database:
+                                            type: string
+                                          host:
+                                            type: string
+                                          port:
+                                            format: int32
+                                            maximum: 65535
+                                            minimum: 1
+                                            type: integer
+                                          serverCACertSecret:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                              - key
+                                            type: object
+                                          user:
+                                            type: string
+                                        required:
+                                          - credentialsSecret
+                                          - database
+                                          - host
+                                          - port
+                                          - user
+                                        type: object
+                                      extraEnv:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                      extraLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      extraVolumeMounts:
+                                        items:
+                                          properties:
+                                            mountPath:
+                                              type: string
+                                            mountPropagation:
+                                              type: string
+                                            name:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            subPath:
+                                              type: string
+                                            subPathExpr:
+                                              type: string
+                                          required:
+                                            - mountPath
+                                            - name
+                                          type: object
+                                        type: array
+                                      extraVolumes:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      initContainers:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      mysqld:
+                                        properties:
+                                          configOverrides:
+                                            type: string
+                                          resources:
+                                            properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                        required:
+                                          - resources
+                                        type: object
+                                      replicas:
+                                        format: int32
+                                        minimum: 0
+                                        type: integer
+                                      sidecarContainers:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      tolerations:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      topologySpreadConstraints:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      type:
+                                        enum:
+                                          - replica
+                                          - rdonly
+                                          - externalmaster
+                                          - externalreplica
+                                          - externalrdonly
+                                        type: string
+                                      vttablet:
+                                        properties:
+                                          extraFlags:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          lifecycle:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          resources:
+                                            properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                  - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                        required:
+                                          - resources
+                                        type: object
+                                    required:
+                                      - cell
+                                      - replicas
+                                      - type
+                                      - vttablet
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - type
+                                    - cell
+                                  x-kubernetes-list-type: map
+                              required:
+                                - databaseInitScriptSecret
+                                - keyRange
+                              type: object
+                            type: array
+                        required:
+                          - shards
+                        type: object
+                      equal:
+                        properties:
+                          parts:
+                            format: int32
+                            maximum: 65536
+                            minimum: 1
+                            type: integer
+                          shardTemplate:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              databaseInitScriptSecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                  - key
+                                type: object
+                              replication:
+                                properties:
+                                  initializeBackup:
+                                    type: boolean
+                                  initializeMaster:
+                                    type: boolean
+                                  recoverRestartedMaster:
+                                    type: boolean
+                                type: object
+                              tabletPools:
+                                items:
+                                  properties:
+                                    affinity:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    backupLocationName:
+                                      type: string
+                                    cell:
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                                      type: string
+                                    dataVolumeClaimTemplate:
+                                      properties:
+                                        accessModes:
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          properties:
+                                            apiGroup:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          required:
+                                            - kind
+                                            - name
+                                          type: object
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                                - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        selector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          type: string
+                                        volumeMode:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      type: object
+                                    externalDatastore:
+                                      properties:
+                                        credentialsSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        database:
+                                          type: string
+                                        host:
+                                          type: string
+                                        port:
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        serverCACertSecret:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        user:
+                                          type: string
+                                      required:
+                                        - credentialsSecret
+                                        - database
+                                        - host
+                                        - port
+                                        - user
+                                      type: object
+                                    extraEnv:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                  - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                  - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                  - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                  - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                    extraLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    extraVolumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                          - mountPath
+                                          - name
+                                        type: object
+                                      type: array
+                                    extraVolumes:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    initContainers:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    mysqld:
+                                      properties:
+                                        configOverrides:
+                                          type: string
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                                - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                      required:
+                                        - resources
+                                      type: object
+                                    replicas:
+                                      format: int32
+                                      minimum: 0
+                                      type: integer
+                                    sidecarContainers:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    tolerations:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    topologySpreadConstraints:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type:
+                                      enum:
+                                        - replica
+                                        - rdonly
+                                        - externalmaster
+                                        - externalreplica
+                                        - externalrdonly
+                                      type: string
+                                    vttablet:
+                                      properties:
+                                        extraFlags:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        lifecycle:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                                - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                      required:
+                                        - resources
+                                      type: object
+                                  required:
+                                    - cell
+                                    - replicas
+                                    - type
+                                    - vttablet
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - type
+                                  - cell
+                                x-kubernetes-list-type: map
+                            required:
+                              - databaseInitScriptSecret
+                            type: object
+                        required:
+                          - parts
+                        type: object
+                    type: object
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                topologyReconciliation:
+                  properties:
+                    pruneCells:
+                      type: boolean
+                    pruneKeyspaces:
+                      type: boolean
+                    pruneShardCells:
+                      type: boolean
+                    pruneShards:
+                      type: boolean
+                    pruneSrvKeyspaces:
+                      type: boolean
+                    pruneTablets:
+                      type: boolean
+                    registerCells:
+                      type: boolean
+                    registerCellsAliases:
+                      type: boolean
+                  type: object
+                turndownPolicy:
+                  enum:
+                    - RequireIdle
+                    - Immediate
+                  type: string
+                updateStrategy:
+                  properties:
+                    external:
+                      properties:
+                        allowResourceChanges:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type:
+                      enum:
+                        - External
+                        - Immediate
+                      type: string
+                  type: object
+                vitessOrchestrator:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraEnv:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    extraFlags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraVolumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      x-kubernetes-preserve-unknown-fields: true
+                    initContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    service:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clusterIP:
+                          type: string
+                      type: object
+                    sidecarContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    tolerations:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                zoneMap:
+                  additionalProperties:
+                    type: string
+                  type: object
+              required:
+                - globalLockserver
+                - name
+                - partitionings
+                - zoneMap
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                idle:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                orphanedShards:
+                  additionalProperties:
+                    properties:
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                    required:
+                      - message
+                      - reason
+                    type: object
+                  type: object
+                partitionings:
+                  items:
+                    properties:
+                      desiredShards:
+                        format: int32
+                        type: integer
+                      desiredTablets:
+                        format: int32
+                        type: integer
+                      readyShards:
+                        format: int32
+                        type: integer
+                      readyTablets:
+                        format: int32
+                        type: integer
+                      servingWrites:
+                        type: string
+                      shardNames:
+                        items:
+                          type: string
+                        type: array
+                      tablets:
+                        format: int32
+                        type: integer
+                      updatedTablets:
+                        format: int32
+                        type: integer
+                    type: object
+                  type: array
+                resharding:
+                  properties:
+                    copyProgress:
+                      type: integer
+                    sourceShards:
+                      items:
+                        type: string
+                      type: array
+                    state:
+                      type: string
+                    targetShards:
+                      items:
+                        type: string
+                      type: array
+                    workflow:
+                      type: string
+                  required:
+                    - state
+                    - workflow
+                  type: object
+                shards:
+                  additionalProperties:
+                    properties:
+                      cells:
+                        items:
+                          type: string
+                        type: array
+                      desiredTablets:
+                        format: int32
+                        type: integer
+                      hasMaster:
+                        type: string
+                      pendingChanges:
+                        type: string
+                      readyTablets:
+                        format: int32
+                        type: integer
+                      servingWrites:
+                        type: string
+                      tablets:
+                        format: int32
+                        type: integer
+                      updatedTablets:
+                        format: int32
+                        type: integer
+                    type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
+  name: vitessshards.planetscale.com
+spec:
+  group: planetscale.com
+  names:
+    kind: VitessShard
+    listKind: VitessShardList
+    plural: vitessshards
+    shortNames:
+      - vts
+    singular: vitessshard
+  scope: Namespaced
+  versions:
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                backupEngine:
+                  type: string
+                backupLocations:
+                  items:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      azblob:
+                        properties:
+                          account:
+                            minLength: 1
+                            type: string
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          container:
+                            minLength: 1
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                        required:
+                          - account
+                          - authSecret
+                          - container
+                        type: object
+                      ceph:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                        required:
+                          - authSecret
+                        type: object
+                      gcs:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            minLength: 1
+                            type: string
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                        required:
+                          - bucket
+                        type: object
+                      name:
+                        maxLength: 63
+                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                        type: string
+                      s3:
+                        properties:
+                          authSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          bucket:
+                            minLength: 1
+                            type: string
+                          endpoint:
+                            type: string
+                          forcePathStyle:
+                            type: boolean
+                          keyPrefix:
+                            maxLength: 256
+                            pattern: ^[^\r\n]*$
+                            type: string
+                          region:
+                            minLength: 1
+                            type: string
+                        required:
+                          - bucket
+                          - region
+                        type: object
+                      volume:
+                        x-kubernetes-preserve-unknown-fields: true
+                      volumeSubPath:
+                        type: string
+                    type: object
+                  type: array
+                databaseInitScriptSecret:
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    volumeName:
+                      type: string
+                  required:
+                    - key
+                  type: object
+                databaseName:
+                  type: string
+                extraVitessFlags:
+                  additionalProperties:
+                    type: string
+                  type: object
+                globalLockserver:
+                  properties:
+                    address:
+                      type: string
+                    implementation:
+                      type: string
+                    rootPath:
+                      type: string
+                  required:
+                    - address
+                    - implementation
+                    - rootPath
+                  type: object
+                imagePullPolicies:
+                  properties:
+                    mysqld:
+                      type: string
+                    mysqldExporter:
+                      type: string
+                    vtadmin:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtctld:
+                      type: string
+                    vtgate:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                imagePullSecrets:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                images:
+                  properties:
+                    mysqld:
+                      properties:
+                        mariadb103Compatible:
+                          type: string
+                        mariadbCompatible:
+                          type: string
+                        mysql56Compatible:
+                          type: string
+                        mysql80Compatible:
+                          type: string
+                      type: object
+                    mysqldExporter:
+                      type: string
+                    vtbackup:
+                      type: string
+                    vtorc:
+                      type: string
+                    vttablet:
+                      type: string
+                  type: object
+                keyRange:
+                  properties:
+                    end:
+                      pattern: ^([0-9a-f][0-9a-f])*$
+                      type: string
+                    start:
+                      pattern: ^([0-9a-f][0-9a-f])*$
+                      type: string
+                  type: object
+                name:
+                  type: string
+                replication:
+                  properties:
+                    initializeBackup:
+                      type: boolean
+                    initializeMaster:
+                      type: boolean
+                    recoverRestartedMaster:
+                      type: boolean
+                  type: object
+                tabletPools:
+                  items:
+                    properties:
+                      affinity:
+                        x-kubernetes-preserve-unknown-fields: true
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      backupLocationName:
+                        type: string
+                      cell:
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                        type: string
+                      dataVolumeClaimTemplate:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                      externalDatastore:
+                        properties:
+                          credentialsSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          database:
+                            type: string
+                          host:
+                            type: string
+                          port:
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          serverCACertSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          user:
+                            type: string
+                        required:
+                          - credentialsSecret
+                          - database
+                          - host
+                          - port
+                          - user
+                        type: object
+                      extraEnv:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      extraLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      extraVolumeMounts:
+                        items:
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                      extraVolumes:
+                        x-kubernetes-preserve-unknown-fields: true
+                      initContainers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      mysqld:
+                        properties:
+                          configOverrides:
+                            type: string
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                        required:
+                          - resources
+                        type: object
+                      replicas:
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      sidecarContainers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      tolerations:
+                        x-kubernetes-preserve-unknown-fields: true
+                      topologySpreadConstraints:
+                        x-kubernetes-preserve-unknown-fields: true
+                      type:
+                        enum:
+                          - replica
+                          - rdonly
+                          - externalmaster
+                          - externalreplica
+                          - externalrdonly
+                        type: string
+                      vttablet:
+                        properties:
+                          extraFlags:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          lifecycle:
+                            x-kubernetes-preserve-unknown-fields: true
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                        required:
+                          - resources
+                        type: object
+                    required:
+                      - cell
+                      - replicas
+                      - type
+                      - vttablet
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                    - cell
+                  x-kubernetes-list-type: map
+                topologyReconciliation:
+                  properties:
+                    pruneCells:
+                      type: boolean
+                    pruneKeyspaces:
+                      type: boolean
+                    pruneShardCells:
+                      type: boolean
+                    pruneShards:
+                      type: boolean
+                    pruneSrvKeyspaces:
+                      type: boolean
+                    pruneTablets:
+                      type: boolean
+                    registerCells:
+                      type: boolean
+                    registerCellsAliases:
+                      type: boolean
+                  type: object
+                updateStrategy:
+                  properties:
+                    external:
+                      properties:
+                        allowResourceChanges:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type:
+                      enum:
+                        - External
+                        - Immediate
+                      type: string
+                  type: object
+                vitessOrchestrator:
+                  properties:
+                    affinity:
+                      x-kubernetes-preserve-unknown-fields: true
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraEnv:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    extraFlags:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    extraVolumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                          - mountPath
+                          - name
+                        type: object
+                      type: array
+                    extraVolumes:
+                      x-kubernetes-preserve-unknown-fields: true
+                    initContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    service:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        clusterIP:
+                          type: string
+                      type: object
+                    sidecarContainers:
+                      x-kubernetes-preserve-unknown-fields: true
+                    tolerations:
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                zoneMap:
+                  additionalProperties:
+                    type: string
+                  type: object
+              required:
+                - databaseInitScriptSecret
+                - globalLockserver
+                - images
+                - keyRange
+                - name
+                - zoneMap
+              type: object
+            status:
+              properties:
+                backupLocations:
+                  items:
+                    properties:
+                      completeBackups:
+                        format: int32
+                        type: integer
+                      incompleteBackups:
+                        format: int32
+                        type: integer
+                      latestCompleteBackupTime:
+                        format: date-time
+                        type: string
+                      name:
+                        type: string
+                    required:
+                      - completeBackups
+                      - incompleteBackups
+                    type: object
+                  type: array
+                cells:
+                  items:
+                    type: string
+                  type: array
+                conditions:
+                  additionalProperties:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                    required:
+                      - status
+                    type: object
+                  type: object
+                hasInitialBackup:
+                  type: string
+                hasMaster:
+                  type: string
+                idle:
+                  type: string
+                lowestPodGeneration:
+                  format: int64
+                  type: integer
+                masterAlias:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                orphanedTablets:
+                  additionalProperties:
+                    properties:
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                    required:
+                      - message
+                      - reason
+                    type: object
+                  type: object
+                servingWrites:
+                  type: string
+                tablets:
+                  additionalProperties:
+                    properties:
+                      available:
+                        type: string
+                      dataVolumeBound:
+                        type: string
+                      index:
+                        format: int32
+                        type: integer
+                      pendingChanges:
+                        type: string
+                      poolType:
+                        type: string
+                      ready:
+                        type: string
+                      running:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: object
+                vitessOrchestrator:
+                  properties:
+                    available:
+                      type: string
+                    serviceName:
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vitess-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vitess-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resourceNames:
+      - vitess-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - planetscale.com
+    resources:
+      - vitessclusters
+      - vitessclusters/status
+      - vitessclusters/finalizers
+      - vitesscells
+      - vitesscells/status
+      - vitesscells/finalizers
+      - vitesskeyspaces
+      - vitesskeyspaces/status
+      - vitesskeyspaces/finalizers
+      - vitessshards
+      - vitessshards/status
+      - vitessshards/finalizers
+      - etcdlockservers
+      - etcdlockservers/status
+      - etcdlockservers/finalizers
+      - vitessbackups
+      - vitessbackups/status
+      - vitessbackups/finalizers
+      - vitessbackupstorages
+      - vitessbackupstorages/status
+      - vitessbackupstorages/finalizers
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vitess-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vitess-operator
+subjects:
+  - kind: ServiceAccount
+    name: vitess-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vitess-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vitess-operator
+  template:
+    metadata:
+      labels:
+        app: vitess-operator
+    spec:
+      containers:
+        - args:
+            - --logtostderr
+            - -v=4
+          command:
+            - vitess-operator
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: PS_OPERATOR_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PS_OPERATOR_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: vitess-operator
+          image: planetscale/vitess-operator:v2.9.0
+          name: vitess-operator
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      priorityClassName: vitess-operator-control-plane
+      serviceAccountName: vitess-operator
+---
+apiVersion: scheduling.k8s.io/v1
+description: The vitess-operator control plane.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: vitess-operator-control-plane
+value: 5000
+---
+apiVersion: scheduling.k8s.io/v1
+description: Vitess components (vttablet, vtgate, vtctld, etcd)
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: vitess
+value: 1000

--- a/vitess/scripts/pf.sh
+++ b/vitess/scripts/pf.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+kubectl port-forward --address localhost "$(kubectl get service --selector="planetscale.com/component=vtctld" -o name | head -n1)" 15000 15999 &
+process_id1=$!
+kubectl port-forward --address localhost "$(kubectl get service --selector="planetscale.com/component=vtgate,!planetscale.com/cell" -o name | head -n1)" 15306:3306 &
+process_id2=$!
+kubectl port-forward --address localhost "$(kubectl get service --selector="planetscale.com/component=vtadmin" -o name | head -n1)" 14000:15000 14001:15001 &
+process_id3=$!
+sleep 2
+echo "You may point your browser to http://localhost:15000, use the following aliases as shortcuts:"
+echo 'alias vtctlclient="vtctlclient --server=localhost:15999 --logtostderr"'
+echo 'alias mysql="mysql -h 127.0.0.1 -P 15306 -u user"'
+echo "Hit Ctrl-C to stop the port forwards"
+wait $process_id1
+wait $process_id2
+wait $process_id3

--- a/vitess/scripts/start.sh
+++ b/vitess/scripts/start.sh
@@ -7,7 +7,7 @@ killall kubectl
 kubectl apply -f ../local/operator.yaml
 checkPodStatusWithTimeout "vitess-operator(.*)1/1(.*)Running(.*)"
 
-kubectl apply -f ../local/01_initial_cluster_updated.yaml
+kubectl apply -f ../local/01-initial-cluster.yaml
 checkPodStatusWithTimeout "vitess-cluster-useast1-vtctld(.*)1/1(.*)Running(.*)"
 checkPodStatusWithTimeout "vitess-cluster-useast1-vtgate(.*)1/1(.*)Running(.*)"
 checkPodStatusWithTimeout "vitess-cluster-etcd(.*)1/1(.*)Running(.*)" 3

--- a/vitess/scripts/start.sh
+++ b/vitess/scripts/start.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-source ./utils.sh
+source ./vitess/scripts/utils.sh
 
 minikube start --kubernetes-version=v1.24.0 --cpus=4 --memory=8000 --disk-size=30g
 killall kubectl
-kubectl apply -f ../local/operator.yaml
+kubectl apply -f ./vitess/local/operator.yaml
 checkPodStatusWithTimeout "vitess-operator(.*)1/1(.*)Running(.*)"
 
-kubectl apply -f ../local/01-initial-cluster.yaml
+kubectl apply -f ./vitess/local/01-initial-cluster.yaml
 checkPodStatusWithTimeout "vitess-cluster-useast1-vtctld(.*)1/1(.*)Running(.*)"
 checkPodStatusWithTimeout "vitess-cluster-useast1-vtgate(.*)1/1(.*)Running(.*)"
 checkPodStatusWithTimeout "vitess-cluster-etcd(.*)1/1(.*)Running(.*)" 3

--- a/vitess/scripts/start.sh
+++ b/vitess/scripts/start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source ./utils.sh
+
+minikube start --kubernetes-version=v1.24.0 --cpus=4 --memory=8000 --disk-size=30g
+killall kubectl
+kubectl apply -f ./operator.yaml
+checkPodStatusWithTimeout "vitess-operator(.*)1/1(.*)Running(.*)"
+
+kubectl apply -f 01_initial_cluster_updated.yaml
+checkPodStatusWithTimeout "vitess-cluster-useast1-vtctld(.*)1/1(.*)Running(.*)"
+checkPodStatusWithTimeout "vitess-cluster-useast1-vtgate(.*)1/1(.*)Running(.*)"
+checkPodStatusWithTimeout "vitess-cluster-etcd(.*)1/1(.*)Running(.*)" 3
+checkPodStatusWithTimeout "vitess-cluster-vttablet-useast1(.*)3/3(.*)Running(.*)" 2
+
+sleep 10
+./pf.sh > /dev/null 2>&1 &
+sleep 5
+
+extTablet=$(vtctlclient ListAllTablets -- --keyspace="extdb" | grep -o -E "useast1-[0-9]*")
+vtctlclient TabletExternallyReparented "$extTablet"

--- a/vitess/scripts/start.sh
+++ b/vitess/scripts/start.sh
@@ -13,5 +13,9 @@ checkPodStatusWithTimeout "vitess-cluster-useast1-vtgate(.*)1/1(.*)Running(.*)"
 checkPodStatusWithTimeout "vitess-cluster-etcd(.*)1/1(.*)Running(.*)" 3
 checkPodStatusWithTimeout "vitess-cluster-vttablet-useast1(.*)3/3(.*)Running(.*)" 2
 
+echo "Found all the required components, please wait..."
+
 sleep 10
-./pf.sh > /dev/null 2>&1 &
+
+echo "Forwarding ports..."
+sh ./vitess/scripts/pf.sh

--- a/vitess/scripts/start.sh
+++ b/vitess/scripts/start.sh
@@ -4,10 +4,10 @@ source ./utils.sh
 
 minikube start --kubernetes-version=v1.24.0 --cpus=4 --memory=8000 --disk-size=30g
 killall kubectl
-kubectl apply -f ./operator.yaml
+kubectl apply -f ../local/operator.yaml
 checkPodStatusWithTimeout "vitess-operator(.*)1/1(.*)Running(.*)"
 
-kubectl apply -f 01_initial_cluster_updated.yaml
+kubectl apply -f ../local/01_initial_cluster_updated.yaml
 checkPodStatusWithTimeout "vitess-cluster-useast1-vtctld(.*)1/1(.*)Running(.*)"
 checkPodStatusWithTimeout "vitess-cluster-useast1-vtgate(.*)1/1(.*)Running(.*)"
 checkPodStatusWithTimeout "vitess-cluster-etcd(.*)1/1(.*)Running(.*)" 3

--- a/vitess/scripts/start.sh
+++ b/vitess/scripts/start.sh
@@ -15,7 +15,3 @@ checkPodStatusWithTimeout "vitess-cluster-vttablet-useast1(.*)3/3(.*)Running(.*)
 
 sleep 10
 ./pf.sh > /dev/null 2>&1 &
-sleep 5
-
-extTablet=$(vtctlclient ListAllTablets -- --keyspace="extdb" | grep -o -E "useast1-[0-9]*")
-vtctlclient TabletExternallyReparented "$extTablet"

--- a/vitess/scripts/utils.sh
+++ b/vitess/scripts/utils.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+shopt -s expand_aliases
+
+echo 'Aliasing `vtctlclient` to the following for easy access'
+echo 'alias vtctlclient="vtctlclient --server=localhost:15999 --logtostderr"'
+alias vtctlclient="vtctlclient --server=localhost:15999 --logtostderr"
+echo
+
+echo 'Aliasing `vtctldclient` to the following for easy access'
+echo 'alias vtctldclient="vtctldclient --server=localhost:15999 --logtostderr"'
+alias vtctldclient="vtctldclient --server=localhost:15999 --logtostderr"
+echo
+
+echo "MySQL can also be aliased to quick access however this is left to you!"
+echo 'alias mysql="mysql -h 127.0.0.1 -P 15306 -u user"'
+echo
+
+# checkPodStatusWithTimeout:
+# $1: regex used to match pod names
+# $2: number of pods to match (default: 1)
+function checkPodStatusWithTimeout() {
+  regex=$1
+  nb=$2
+
+  # Number of pods to match defaults to one
+  if [ -z "$nb" ]; then
+    nb=1
+  fi
+
+  # We use this for loop instead of `kubectl wait` because we don't have access to the full pod name
+  # and `kubectl wait` does not support regex to match resource name.
+  for i in {1..1200} ; do
+    out=$(kubectl get pods)
+    echo "$out" | grep -E "$regex" | wc -l | grep "$nb" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      echo "$regex found"
+      return
+    fi
+    sleep 1
+  done
+  echo -e "ERROR: checkPodStatusWithTimeout timeout to find pod matching:\ngot:\n$out\nfor regex: $regex"
+  exit 1
+}


### PR DESCRIPTION
### Description 🎯

[Vitess](https://vitess.io/) is a scalable cloud-native database layer that internally uses MySQL as database. However the layer created by Vitess makes MySQL sharding easier to do and use. It also manages the entire part of sharding and stuff. Which also means that this exposes only one mysql instance, therefore your application thinks its just talking to one mysqld instance!

---

### Requirements 🤖

- To make this work you must have `minikube` on your local machine (for Cloud the operator is provided)
- To must allocate memory based on your requirement, for initial the requirements is set to absolute minimum (you need at the very least 8 GB of memory)
- You must have docker installed since this works by default using docker runtime

---

### Changes 📝

- Added scripts for initializing Vitess cluster
- Initial Vitess cluster configuration
- Utility scripts for various utilities (feel free to use them without initial script too)
